### PR TITLE
Better search result sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,22 @@ relic.
 ## Setup
 
 ```bash
+# in backend/
+
 # install python dependencies
 uv venv --seed
 . venv/bin/activate
 uv pip install
-
-# front-end
-npm install
 
 # fetch data, create events.db
 make
 
 # start the backend
 FLASK_DEBUG=true python app.py
+
+# in frontend/
+
+npm install
 
 # start the frontend
 npm run dev

--- a/backend/taxonomy_time_machine/load_data.py
+++ b/backend/taxonomy_time_machine/load_data.py
@@ -155,7 +155,7 @@ def main() -> None:
     # as GTDB-Tk which lack IDs
     # (you can use the name as the ID)
     cursor.execute("""
-    CREATE TABLE IF NOT EXISTS taxonomy (
+    CREATE TABLE taxonomy (
         event_name TEXT,
         version_date DATETIME,
         tax_id TEXT,

--- a/backend/taxonomy_time_machine/models.py
+++ b/backend/taxonomy_time_machine/models.py
@@ -92,7 +92,8 @@ class Taxonomy:
         self.cursor = self.conn.cursor()
 
     def search_names(self, query: str, limit: int | None = 10) -> list[Event]:
-        matches = []
+        matches: list[dict] = []
+        exact_matches: list[dict] = []
 
         # first, check if the query is tax-ID like
         if query.isnumeric():
@@ -101,20 +102,27 @@ class Taxonomy:
                 (query,),
             ).fetchall()
 
-            matches.extend([dict(r) for r in rows])
+            exact_matches.extend([dict(r) for r in rows])
 
-        # first look for exact mathes (case insensitive)
-        # LIKE is too slow...
-        matches.extend(
-            [
-                dict(r)
-                for r in self.cursor.execute(
-                    "SELECT * FROM taxonomy WHERE name LIKE ? LIMIT ?;", (f"{query}%", 10)
-                ).fetchall()
-            ]
-        )
+        if limit is None or (len(matches) + len(exact_matches) < limit):
+            # first look for exact mathes (case insensitive)
+            # LIKE is too slow...
+            matches.extend(
+                [
+                    dict(r)
+                    for r in self.cursor.execute(
+                        """SELECT *
+                        FROM taxonomy
+                        WHERE name LIKE ?
+                        ORDER BY LENGTH(name) ASC
+                        LIMIT ?;
+                        """,
+                        (f"{query}%", 10),
+                    ).fetchall()
+                ]
+            )
 
-        if limit is None or len(matches) < limit:
+        if limit is None or (len(matches) + len(exact_matches)) < limit:
             # fuzzy matches
             matches.extend(
                 [
@@ -124,7 +132,8 @@ class Taxonomy:
                     SELECT taxonomy.tax_id, taxonomy.name, taxonomy.rank, taxonomy.event_name, taxonomy.version_date
                     FROM name_fts
                     JOIN taxonomy ON name_fts.name = taxonomy.name
-                    WHERE name_fts MATCH ? order by name_fts.rank
+                    WHERE name_fts MATCH ?
+                    ORDER BY LENGTH(taxonomy.name) ASC
                     LIMIT ?
                     ;
                     """,
@@ -133,14 +142,15 @@ class Taxonomy:
                 ]
             )
 
-        matches_events = [Event.from_dict(m) for m in matches]
+        # sort by closest match (probably the shortest)
+        matches = sorted(matches, key=lambda m: len(m["name"]))
 
-        results = []
+        # exact matches should always come first
+        # + truncate to limit
+        # + convert to Events
+        events = [Event.from_dict(m) for m in (exact_matches + matches)[:limit]]
 
-        for row in matches_events:
-            results.append(row)
-
-        return results[:limit]
+        return events
 
     def get_events(
         self,

--- a/backend/test_models.py
+++ b/backend/test_models.py
@@ -187,7 +187,7 @@ def test_get_children(db):
 
 
 def test_lineage(db):
-    events = db.get_lineage(tax_id="821")
+    events = db.get_lineage(tax_id="821", as_of=datetime(2024, 12, 11, 0, 0))
 
     assert [x.name for x in events] == [
         "Phocaeicola vulgatus",

--- a/backend/test_models.py
+++ b/backend/test_models.py
@@ -24,6 +24,17 @@ def test_search_names(db):
     assert matches
 
 
+def test_search_names_numeric(db):
+    # first hit should always be exact tax ID match
+    matches = [m.to_dict() for m in db.search_names("4932", limit=None)]
+    assert matches[0]["name"] == "Saccharomyces cerevisiae"
+
+
+def test_match_should_be_most_specific(db):
+    matches = [m.to_dict() for m in db.search_names("Saccharomyces cere", limit=None)]
+    assert matches[0]["name"] == "Saccharomyces cerevisiae"
+
+
 def test_get_children_deleted_node(db):
     # currently, this node has no children because it was deleted
     events = db.get_events("352463")


### PR DESCRIPTION
For #2 

- Sort matches from shortest to longest. This should result in the most-specific hits being first
- Fix tax ID matches not always being first if tax ID found in other taxa names
- Misc. fixes + docs