### PR TITLE
Frontend Style/Copy Updates + Example Queries

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,6 @@ dependencies = [
     "flask>=3.1.0",
     "polars>=1.13.1",
     "pytest>=8.3.3",
-    "taxonomy>=0.10.0",
+    "taxonomy>=0.10.1",
     "tqdm>=4.67.0",
 ]

--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -1,0 +1,68 @@
+/* Global styles for Taxonomy Time Machine */
+
+body, html, input, textarea, select, button, code, pre, table, th, td {
+  font-family: 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace !important;
+}
+
+* {
+  font-family: inherit !important;
+}
+
+.read-the-docs {
+  color: #888;
+}
+
+/* Add any component-specific styles here, e.g. for dropdown, search, etc. */
+
+.search-component {
+  position: relative;
+}
+
+.dropdown.is-active .dropdown-menu {
+  display: block;
+}
+
+
+.dropdown-item.is-active {
+  background-color: #f5f5f5;
+  color: #363636;
+}
+
+.dropdown-item {
+  cursor: pointer;
+}
+
+.input.is-large {
+  font-size: 1.25rem;
+}
+
+.table {
+  width: 100%;
+  margin-bottom: 1rem;
+  background-color: #fff;
+}
+
+.table th, .table td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.has-text-danger {
+  color: #f14668;
+}
+
+/* Breadcrumb: ensure all items have same padding */
+.breadcrumb li a {
+  padding: 0.2em 0.6em;
+}
+
+.breadcrumb li.is-active a {
+  background: #e0e0e0;
+  color: #222 !important;
+  border-radius: 4px;
+  font-weight: bold;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  transition: background 0.2s;
+}
+
+/* Add more as needed */

--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -65,4 +65,19 @@ body, html, input, textarea, select, button, code, pre, table, th, td {
   transition: background 0.2s;
 }
 
-/* Add more as needed */
+/* Current taxon summary with dark mode support */
+.current-taxon-summary {
+  font-size: 1.1em;
+  background: #f8f8f8;
+  border-radius: 6px;
+  padding: 1em;
+  border: 1px solid #e0e0e0;
+  color: #222;
+}
+@media (prefers-color-scheme: dark) {
+  .current-taxon-summary {
+    background: #23272e;
+    border: 1px solid #444b53;
+    color: #f3f3f3;
+  }
+}

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -440,9 +440,3 @@ export default defineComponent({
 
   <!-- Results -->
 </template>
-
-<style scoped>
-.read-the-docs {
-  color: #888;
-}
-</style>

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -282,6 +282,12 @@ export default defineComponent({
       version.value = argVersion;
     };
 
+    // --- Add this function to handle example clicks ---
+    const handleExampleClick = async (example: string) => {
+      query.value = example;
+      await findTaxId();
+    };
+
     return {
       emoji,
       taxId,
@@ -306,6 +312,7 @@ export default defineComponent({
       highlightPrev,
       selectHighlighted,
       highlightedIndex,
+      handleExampleClick,
     };
   },
 });
@@ -321,6 +328,25 @@ export default defineComponent({
 
   <section class="section">
     <div class="container">
+      <!-- Example Taxa Buttons -->
+      <div class="example-taxa-buttons" style="margin-bottom: 1em;">
+        <span style="margin-right: 0.5em; font-weight: bold;">Examples:</span>
+        <button
+          v-for="example in [
+            'Wuhan seafood market pneumonia virus',
+            'Bacteroides dorei',
+            'Lactobacillus reuteri',
+            '[Candida] auris'
+          ]"
+          :key="example"
+          class="button is-small is-info"
+          style="margin-right: 0.5em; margin-bottom: 0.5em;"
+          @click="() => handleExampleClick(example)"
+        >
+          {{ example }}
+        </button>
+      </div>
+
       <div class="field">
         <div
           class="control is-expanded is-large"

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -403,7 +403,24 @@ export default defineComponent({
             </table>
             <p>
               Showing lineage of Tax ID <code>{{ taxId }}</code> from
-              <code>{{ version }}</code>
+              <code>{{ version }}</code> retrieved from
+              <span v-if="version">
+                <span style="font-size:0.95em;word-break:break-all;">
+                  <code>
+                    {{
+                      `https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_${formatDate(version)}.zip`
+                    }}
+                  </code>
+                  <a
+                    :href="`https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_${formatDate(version)}.zip`"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style="margin-left: 0.5em; font-size: 0.95em;"
+                  >
+                    [download]
+                  </a>
+                </span>
+              </span>
             </p>
           </div>
         </div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 
+import "./assets/styles.css";
 import "bulma/css/bulma.css";
 
 createApp(App).mount("#app");


### PR DESCRIPTION
- Upgrade taxonomy lib to `0.10.1`
- Some style changes
- Added a description of the current result and indicate the current name
- Added buttons to example queries

![Screenshot 2025-05-24 at 1 25 27 PM](https://github.com/user-attachments/assets/f7c064f6-5ba4-4a91-bc8a-bef38c692def)
