### PR TITLE
Improve landing page for taxon

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -162,6 +162,15 @@ EVENTS = [
         "event_name": "delete",
         "version_date": D2,
     },
+    # Rename of DeletedGenus *after* its child was deleted — should not appear in child's versions
+    {
+        "tax_id": "1000",
+        "name": "RenamedDeletedGenus",
+        "parent_id": "2",
+        "rank": "genus",
+        "event_name": "alter",
+        "version_date": D3,
+    },
     # Moved node: 2002 created under 2000, then moved to 2001 at D2
     {
         "tax_id": "2000",

--- a/backend/taxonomy_time_machine/time_machine.py
+++ b/backend/taxonomy_time_machine/time_machine.py
@@ -281,6 +281,17 @@ class TimeMachine:
                     break
 
             if parent is not None:
+                if parent.event_name == EventName.Delete:
+                    last_known = next((e for e in reversed(events) if e.name), None)
+                    if last_known:
+                        parent = Event(
+                            event_name=parent.event_name,
+                            tax_id=parent.tax_id,
+                            version_date=parent.version_date,
+                            name=last_known.name,
+                            rank=last_known.rank,
+                            parent_id=parent.parent_id,
+                        )
                 lineage.append(parent)
             else:
                 break

--- a/backend/taxonomy_time_machine/time_machine.py
+++ b/backend/taxonomy_time_machine/time_machine.py
@@ -233,18 +233,24 @@ class TimeMachine:
         changed"""
         _profile_start = time.perf_counter()
 
-        # TODO: handle deletions (example: 352463)
+        # Find deletion date for this taxon (if deleted)
+        own_events = self.get_events(tax_id=tax_id)
+        deletion_date = None
+        if own_events and own_events[-1].event_name == EventName.Delete:
+            deletion_date = own_events[-1].version_date
+
         events = self._get_all_events_recursive(tax_id=tax_id)
         version_dates = sorted({e.version_date for e in events})
+
+        # Don't show lineage changes that happened after this taxon was deleted
+        if deletion_date:
+            version_dates = [d for d in version_dates if d <= deletion_date]
 
         seen_lineages = set()
         versions_with_changes = []
 
         for version_date in version_dates:
             events = self.get_lineage(tax_id=tax_id, as_of=version_date)
-
-            # TODO: can a tax_id by deleted and created in the same version?
-            # TODO: can a tax_id be re-created after being deleted?
 
             key = tuple([(e.rank, e.tax_id, e.parent_id, e.name) for e in events])
 
@@ -256,6 +262,11 @@ class TimeMachine:
             if key not in seen_lineages:
                 versions_with_changes.append(version_date)
             seen_lineages.add(key)
+
+        # Always include the deletion date as a version point (for the timeline dot)
+        if deletion_date and deletion_date not in versions_with_changes:
+            versions_with_changes.append(deletion_date)
+            versions_with_changes.sort()
 
         self._profile("get_versions", _profile_start, time.perf_counter())
         return versions_with_changes

--- a/backend/test_models.py
+++ b/backend/test_models.py
@@ -133,6 +133,25 @@ def test_get_versions(db):
     assert len(lineages) == len(set(lineages))
 
 
+def test_get_versions_deleted_node_stops_at_deletion(db):
+    # 1001 was deleted at D2; its parent was renamed at D3
+    # versions should not include D3 or later
+    versions = db.get_versions("1001")
+    assert all(v <= D2 for v in versions), f"Expected no versions after D2, got {versions}"
+
+
+def test_get_versions_deleted_node_includes_deletion_date(db):
+    # D2 is the deletion date and must always appear as a dot on the timeline
+    versions = db.get_versions("1001")
+    assert D2 in versions, f"Expected deletion date D2 in versions, got {versions}"
+
+
+def test_get_versions_deleted_node_includes_creation(db):
+    # D1 is when 1001 was created — should still appear
+    versions = db.get_versions("1001")
+    assert D1 in versions, f"Expected creation date D1 in versions, got {versions}"
+
+
 def test_get_children(db):
     children = db.get_children(tax_id="3000")
     assert children

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -59,6 +59,11 @@ export default defineComponent({
       return date.toLocaleDateString(undefined, { year: "numeric", month: "short" });
     };
 
+    const formatYearMonth = (isoDate: string | null): string => {
+      if (!isoDate) return "";
+      return isoDate.slice(0, 7); // "YYYY-MM"
+    };
+
     // ~~~~~~~~~~~~~~~~~~~
     // reactive properties
     // ~~~~~~~~~~~~~~~~~~~
@@ -476,6 +481,7 @@ export default defineComponent({
       formatDate,
       formatDisplayDate,
       formatShortDate,
+      formatYearMonth,
       suggestions,
       loading,
       fetchSuggestions,
@@ -617,6 +623,10 @@ export default defineComponent({
         <span class="taxon-info-box__status">
           <template v-if="isLatestVersion">
             Most recent version
+          </template>
+          <template v-else-if="currentTaxon.event_name === 'delete'">
+            As of {{ formatDisplayDate(version) }} ·
+            <span class="change-badge change-badge--deleted">deleted on {{ formatYearMonth(currentTaxon.version_date) }}</span>
           </template>
           <template v-else-if="taxonChanges && (taxonChanges.nameChanged || taxonChanges.lineageChanged)">
             As of {{ formatDisplayDate(version) }} ·
@@ -1235,6 +1245,11 @@ export default defineComponent({
   color: #8a5a00;
 }
 
+.change-badge--deleted {
+  background: #fde8e8;
+  color: #c0392b;
+}
+
 .deleted-badge {
   display: inline-block;
   margin-left: 0.5em;
@@ -1281,6 +1296,11 @@ export default defineComponent({
   .change-badge--name {
     background: #3d2a00;
     color: #ffd97a;
+  }
+
+  .change-badge--deleted {
+    background: #4a1a1a;
+    color: #ff8a80;
   }
 
   .deleted-badge {

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -293,6 +293,11 @@ export default defineComponent({
 
       lineage.value = data || [];
 
+      if (!userIsTyping.value && lineage.value.length > 0) {
+        const name = lineage.value[lineage.value.length - 1].name;
+        if (name) query.value = name;
+      }
+
       if (lineage.value.some((item) => item.name === "Fungi")) {
         emoji.value = "🍄";
       } else if (lineage.value.some((item) => item.name === "Bacteria")) {
@@ -333,6 +338,15 @@ export default defineComponent({
       const url = `${apiBase}/versions?tax_id=${encodeURIComponent(taxId.value)}`;
       const data = await apiFetchWithCache(url);
       versions.value = data || [];
+
+      if (!version.value && versions.value.length > 0) {
+        const latest = versions.value.reduce((max, v) => {
+          if (!v.version_date) return max;
+          if (!max.version_date) return v;
+          return v.version_date > max.version_date ? v : max;
+        }, versions.value[0]);
+        if (latest.version_date) version.value = latest.version_date;
+      }
     };
 
     const updateTaxId = (argTaxId: string) => {
@@ -403,6 +417,16 @@ export default defineComponent({
       userIsTyping.value = false;
     });
 
+    const isLatestVersion = computed(() => {
+      if (!version.value || versions.value.length === 0) return false;
+      const latest = versions.value.reduce((max, v) => {
+        if (!v.version_date) return max;
+        if (!max.version_date) return v;
+        return v.version_date > max.version_date ? v : max;
+      }, versions.value[0]);
+      return latest.version_date === version.value;
+    });
+
     // Function to get CSS class for rank badges
     const getRankClass = (rank: string | null): string => {
       if (!rank) return "rank-default";
@@ -455,6 +479,7 @@ export default defineComponent({
       handleRandomSpecies,
       randomSpeciesLoading,
       currentTaxon,
+      isLatestVersion,
       getRankClass,
     };
   },
@@ -581,12 +606,19 @@ export default defineComponent({
         style="margin-bottom: 2em; margin-top: 1em"
       >
         <p class="current-taxon-summary">
-          Currently viewing the NCBI taxonomy for
-          <strong>{{ lineage[lineage.length - 1].name }}</strong>
-          ({{ taxId }}) from {{ formatDisplayDate(version) }}.<br />
-          The current name for this taxon is
-          <strong>{{ currentTaxon.name }}</strong
-          >.
+          Viewing <strong>{{ lineage[lineage.length - 1].name }}</strong> ({{ taxId }})
+          <template v-if="isLatestVersion">
+            — this is the most recent version.
+          </template>
+          <template v-else>
+            as of {{ formatDisplayDate(version) }}
+            <template v-if="currentTaxon && currentTaxon.name === lineage[lineage.length - 1].name">
+              — the name hasn't changed.
+            </template>
+            <template v-else>
+              — currently known as <strong>{{ currentTaxon.name }}</strong>.
+            </template>
+          </template>
         </p>
       </div>
 

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -545,6 +545,7 @@ export default defineComponent({
           v-for="example in [
             'SARS-related coronavirus',
             'Bacteroides dorei',
+            'BK polyomavirus',
             'Lactobacillus reuteri',
             '[Candida] auris',
           ]"

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -338,15 +338,6 @@ export default defineComponent({
       const url = `${apiBase}/versions?tax_id=${encodeURIComponent(taxId.value)}`;
       const data = await apiFetchWithCache(url);
       versions.value = data || [];
-
-      if (!version.value && versions.value.length > 0) {
-        const latest = versions.value.reduce((max, v) => {
-          if (!v.version_date) return max;
-          if (!max.version_date) return v;
-          return v.version_date > max.version_date ? v : max;
-        }, versions.value[0]);
-        if (latest.version_date) version.value = latest.version_date;
-      }
     };
 
     const updateTaxId = (argTaxId: string) => {
@@ -412,13 +403,26 @@ export default defineComponent({
       fetchCurrentTaxon();
     });
 
+
     // When taxId changes due to URL or navigation, reset userIsTyping so input box updates
     watch([taxId, version], () => {
       userIsTyping.value = false;
     });
 
+    const taxonChanges = computed(() => {
+      if (!currentTaxon.value || !lineage.value.length) return null;
+      const historical = lineage.value[lineage.value.length - 1];
+      return {
+        nameChanged: currentTaxon.value.name !== historical.name,
+        lineageChanged:
+          currentTaxon.value.rank !== historical.rank ||
+          currentTaxon.value.parent_id !== historical.parent_id,
+      };
+    });
+
     const isLatestVersion = computed(() => {
-      if (!version.value || versions.value.length === 0) return false;
+      if (!version.value) return true;
+      if (versions.value.length === 0) return false;
       const latest = versions.value.reduce((max, v) => {
         if (!v.version_date) return max;
         if (!max.version_date) return v;
@@ -479,6 +483,7 @@ export default defineComponent({
       handleRandomSpecies,
       randomSpeciesLoading,
       currentTaxon,
+      taxonChanges,
       isLatestVersion,
       getRankClass,
     };
@@ -593,34 +598,35 @@ export default defineComponent({
         </div>
       </div>
 
+      <!-- Current Taxon Info -->
+      <div
+        v-if="taxId && lineage.length && currentTaxon"
+        class="taxon-info-box"
+        :class="isLatestVersion ? 'taxon-info-box--latest' : 'taxon-info-box--historical'"
+      >
+        <span class="taxon-info-box__name">{{ lineage[lineage.length - 1].name }}</span>
+        <span class="taxon-info-box__id">tax ID {{ taxId }}</span>
+        <span class="taxon-info-box__status">
+          <template v-if="isLatestVersion">
+            Most recent version
+          </template>
+          <template v-else-if="taxonChanges && (taxonChanges.nameChanged || taxonChanges.lineageChanged)">
+            As of {{ formatDisplayDate(version) }} ·
+            <span v-if="taxonChanges.lineageChanged" class="change-badge change-badge--lineage">reclassified</span>
+            <span v-if="taxonChanges.nameChanged" class="change-badge change-badge--name">renamed to <strong>{{ currentTaxon.name }}</strong></span>
+          </template>
+          <template v-else>
+            As of {{ formatDisplayDate(version) }} · no changes
+          </template>
+        </span>
+      </div>
+
       <!-- Timeline Component -->
-      <Timeline 
-        :versions="versions" 
+      <Timeline
+        :versions="versions"
         :current-version="version"
         @update-version="updateVersion"
       />
-
-      <!-- Current Taxon Info (moved above columns for better visibility) -->
-      <div
-        v-if="taxId && version && lineage.length && currentTaxon"
-        style="margin-bottom: 2em; margin-top: 1em"
-      >
-        <p class="current-taxon-summary">
-          Viewing <strong>{{ lineage[lineage.length - 1].name }}</strong> ({{ taxId }})
-          <template v-if="isLatestVersion">
-            — this is the most recent version.
-          </template>
-          <template v-else>
-            as of {{ formatDisplayDate(version) }}
-            <template v-if="currentTaxon && currentTaxon.name === lineage[lineage.length - 1].name">
-              — the name hasn't changed.
-            </template>
-            <template v-else>
-              — currently known as <strong>{{ currentTaxon.name }}</strong>.
-            </template>
-          </template>
-        </p>
-      </div>
 
       <!-- Lineage table -->
       <div v-if="!!lineage.length" class="taxonomy-section">
@@ -1153,6 +1159,105 @@ export default defineComponent({
   .current-taxon-summary {
     font-size: 0.9rem;
     line-height: 1.4;
+  }
+}
+
+.taxon-info-box {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 8px;
+  border-left: 4px solid;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+.taxon-info-box--latest {
+  background: #f0faf4;
+  border-color: #48c78e;
+}
+
+.taxon-info-box--historical {
+  background: #f5f7ff;
+  border-color: #7b8cde;
+}
+
+.taxon-info-box__name {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.taxon-info-box__id {
+  color: #666;
+  font-size: 0.85rem;
+  font-family: monospace;
+}
+
+.taxon-info-box__status {
+  color: #444;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.change-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.change-badge--lineage {
+  background: #e8e0ff;
+  color: #5a3fc0;
+}
+
+.change-badge--name {
+  background: #fff0d0;
+  color: #8a5a00;
+}
+
+@media screen and (max-width: 600px) {
+  .taxon-info-box__status {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .taxon-info-box--latest {
+    background: #0d2b1e;
+    border-color: #48c78e;
+  }
+
+  .taxon-info-box--historical {
+    background: #161b35;
+    border-color: #7b8cde;
+  }
+
+  .taxon-info-box__id {
+    color: #aaa;
+  }
+
+  .taxon-info-box__status {
+    color: #ccc;
+  }
+
+  .change-badge--lineage {
+    background: #2e1f6e;
+    color: #c4aaff;
+  }
+
+  .change-badge--name {
+    background: #3d2a00;
+    color: #ffd97a;
   }
 }
 </style>

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -10,6 +10,7 @@ interface TaxonVersion {
   name: string | null;
   rank: string | null;
   version_date: string | null;
+  event_name?: string;
 }
 
 export default defineComponent({
@@ -50,6 +51,12 @@ export default defineComponent({
         month: "long",
         day: "numeric",
       });
+    };
+
+    const formatShortDate = (isoDate: string | null): string => {
+      if (!isoDate) return "";
+      const date = new Date(isoDate);
+      return date.toLocaleDateString(undefined, { year: "numeric", month: "short" });
     };
 
     // ~~~~~~~~~~~~~~~~~~~
@@ -468,6 +475,7 @@ export default defineComponent({
       setTaxId,
       formatDate,
       formatDisplayDate,
+      formatShortDate,
       suggestions,
       loading,
       fetchSuggestions,
@@ -641,13 +649,16 @@ export default defineComponent({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="node in lineage" :key="node.tax_id">
+              <tr v-for="node in lineage" :key="node.tax_id" :class="{ 'lineage-row--deleted': node.event_name === 'delete' }">
                 <td>
-                  <span class="rank-badge" :class="getRankClass(node.rank)">
+                  <span class="rank-badge" :class="getRankClass(node.rank)" :style="node.event_name === 'delete' ? 'opacity: 0.5' : ''">
                     {{ node.rank }}
                   </span>
                 </td>
-                <td class="name-cell">{{ node.name }}</td>
+                <td class="name-cell">
+                  <span :style="node.event_name === 'delete' ? 'text-decoration: line-through; opacity: 0.6' : ''">{{ node.name }}</span>
+                  <span v-if="node.event_name === 'delete'" class="deleted-badge">deleted {{ formatShortDate(node.version_date) }}</span>
+                </td>
                 <td>
                   <a
                     href="#"
@@ -1224,6 +1235,18 @@ export default defineComponent({
   color: #8a5a00;
 }
 
+.deleted-badge {
+  display: inline-block;
+  margin-left: 0.5em;
+  padding: 0.1em 0.45em;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: 600;
+  background: #fde8e8;
+  color: #c0392b;
+  vertical-align: middle;
+}
+
 @media screen and (max-width: 600px) {
   .taxon-info-box__status {
     margin-left: 0;
@@ -1258,6 +1281,11 @@ export default defineComponent({
   .change-badge--name {
     background: #3d2a00;
     color: #ffd97a;
+  }
+
+  .deleted-badge {
+    background: #4a1a1a;
+    color: #ff8a80;
   }
 }
 </style>

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -624,7 +624,7 @@ export default defineComponent({
           <template v-if="isLatestVersion">
             Most recent version
           </template>
-          <template v-else-if="currentTaxon.event_name === 'delete'">
+          <template v-else-if="currentTaxon.event_name === 'EventName.Delete'">
             As of {{ formatDisplayDate(version) }} ·
             <span class="change-badge change-badge--deleted">deleted on {{ formatYearMonth(currentTaxon.version_date) }}</span>
           </template>
@@ -659,15 +659,15 @@ export default defineComponent({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="node in lineage" :key="node.tax_id" :class="{ 'lineage-row--deleted': node.event_name === 'delete' }">
+              <tr v-for="node in lineage" :key="node.tax_id" :class="{ 'lineage-row--deleted': node.event_name === 'EventName.Delete' }">
                 <td>
-                  <span class="rank-badge" :class="getRankClass(node.rank)" :style="node.event_name === 'delete' ? 'opacity: 0.5' : ''">
+                  <span class="rank-badge" :class="getRankClass(node.rank)" :style="node.event_name === 'EventName.Delete' ? 'opacity: 0.5' : ''">
                     {{ node.rank }}
                   </span>
                 </td>
                 <td class="name-cell">
-                  <span :style="node.event_name === 'delete' ? 'text-decoration: line-through; opacity: 0.6' : ''">{{ node.name }}</span>
-                  <span v-if="node.event_name === 'delete'" class="deleted-badge">deleted {{ formatShortDate(node.version_date) }}</span>
+                  <span :style="node.event_name === 'EventName.Delete' ? 'text-decoration: line-through; opacity: 0.6' : ''">{{ node.name }}</span>
+                  <span v-if="node.event_name === 'EventName.Delete'" class="deleted-badge">deleted {{ formatShortDate(node.version_date) }}</span>
                 </td>
                 <td>
                   <a

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -55,8 +55,9 @@ export default defineComponent({
 
     const formatShortDate = (isoDate: string | null): string => {
       if (!isoDate) return "";
-      const date = new Date(isoDate);
-      return date.toLocaleDateString(undefined, { year: "numeric", month: "short" });
+      const [year, month] = isoDate.slice(0, 7).split('-');
+      const date = new Date(parseInt(year), parseInt(month) - 1, 1);
+      return date.toLocaleDateString('en-US', { year: "numeric", month: "short" });
     };
 
     const formatYearMonth = (isoDate: string | null): string => {

--- a/frontend/src/components/TaxonomyTimeMachine/Timeline.vue
+++ b/frontend/src/components/TaxonomyTimeMachine/Timeline.vue
@@ -58,7 +58,7 @@ const timelineData = computed(() => {
     return {
       ...version,
       position,
-      labelPosition: position, // Start with same position as dot
+      labelPosition: position,
       isActive: version.version_date === props.currentVersion,
       isFirst: index === 0,
       isLast: index === sortedVersions.value.length - 1,


### PR DESCRIPTION
1. When you land on a taxon page, the name is shown in the text box and the description box is also displayed
2. Improve look of description box
3. Display deletion info in frontend and API (fixes #1, DEV-11527)

### Improved Summary Box

<img width="1405" height="500" alt="Screenshot 2026-04-03 at 1 44 21 PM" src="https://github.com/user-attachments/assets/644e73cd-7496-438e-b30d-c6046fac6967" />


### Deletion Info


<img width="1562" height="1287" alt="Screenshot 2026-04-03 at 1 57 47 PM" src="https://github.com/user-attachments/assets/2e7d2f4e-90ce-4a8d-b73f-dbb4ba9315b3" />
