### PR TITLE
Track and display merged taxa

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ curl 'https://taxonomy.onecodex.com/api/lineage?tax_id=821&version_date=2014-10-
     "parent_id": 1,
     "rank": "no rank",
     "tax_id": 131567,
-    "version_date": "2010-10-22T00:00:00"
+    "version_date": "2010-10-22T00:00:00",
+    "merged_into_id": null
   },
 ]
 ```
@@ -126,7 +127,8 @@ curl 'https://taxonomy.onecodex.com/api/search?query=bacteroides%20dorei%CAG' | 
     "parent_id": 139043,
     "rank": "species",
     "tax_id": 1263042,
-    "version_date": "2014-08-01T00:00:00"
+    "version_date": "2014-08-01T00:00:00",
+    "merged_into_id": null
   }
 ]
 ```
@@ -151,7 +153,8 @@ curl 'https://taxonomy.onecodex.com/api/events?tax_id=821' | jq
     "parent_id": 816,
     "rank": "species",
     "tax_id": 821,
-    "version_date": "2010-10-22T00:00:00"
+    "version_date": "2010-10-22T00:00:00",
+    "merged_into_id": null
   },
   ...
 ]
@@ -180,7 +183,8 @@ curl 'https://taxonomy.onecodex.com/api/children?tax_id=1&version_date=2010-10-2
     "parent_id": 1,
     "rank": "no rank",
     "tax_id": 12884,
-    "version_date": "2010-10-22T00:00:00"
+    "version_date": "2010-10-22T00:00:00",
+    "merged_into_id": null
   },
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ relic.
 uv venv
 uv sync
 
+# install project scripts (i.e., ttm-load)
+uv pip install -e .
+
 # fetch data, create events.db
 make
 

--- a/backend/alembic/versions/c41a46328d8d_add_merged_into_id_column.py
+++ b/backend/alembic/versions/c41a46328d8d_add_merged_into_id_column.py
@@ -1,0 +1,34 @@
+"""add merged_into_id column
+
+Revision ID: c41a46328d8d
+Revises: 4bb4acc2c8d3
+Create Date: 2026-05-02 18:40:27.163153
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c41a46328d8d"
+down_revision: Union[str, Sequence[str], None] = "4bb4acc2c8d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "taxonomy",
+        sa.Column("merged_into_id", sa.Text(), nullable=True),
+    )
+    op.create_index("idx_merged_into_id", "taxonomy", ["merged_into_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_merged_into_id", "taxonomy")
+    op.drop_column("taxonomy", "merged_into_id")

--- a/backend/app.py
+++ b/backend/app.py
@@ -108,6 +108,10 @@ class TaxonSchema(ma.Schema):
         allow_none=True,
         metadata={"description": "Parent taxon ID", "example": "9605"},
     )
+    merged_into_id = ma.fields.String(
+        allow_none=True,
+        metadata={"description": "Tax ID this taxon was merged into", "example": "9606"},
+    )
     version_date = ma.fields.NaiveDateTime(
         metadata={
             "description": "ISO8601-formatted datetime",

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -213,6 +213,48 @@ EVENTS = [
         "event_name": "create",
         "version_date": D1,
     },
+    # Taxon A is merged into Taxon B
+    {
+        "tax_id": "10000",
+        "name": "Phylum Taxon",
+        "parent_id": "2",
+        "rank": "phylum",
+        "event_name": "create",
+        "version_date": D1,
+    },
+    {
+        "tax_id": "10001",
+        "name": "Genus Taxon",
+        "parent_id": "10000",
+        "rank": "genus",
+        "event_name": "create",
+        "version_date": D1,
+    },
+    {
+        "tax_id": "10010",
+        "name": "Taxon A",
+        "parent_id": "10001",
+        "rank": "species",
+        "event_name": "create",
+        "version_date": D1,
+    },
+    {
+        "tax_id": "11000",
+        "name": "Taxon B",
+        "parent_id": "10001",
+        "rank": "species",
+        "event_name": "create",
+        "version_date": D1,
+    },
+    {
+        "tax_id": "10010",
+        "name": "Taxon A",
+        "parent_id": "10001",
+        "rank": "species",
+        "event_name": "merge",
+        "version_date": D2,
+        "merged_into_id": "11000",
+    },
 ]
 
 

--- a/backend/taxonomy_time_machine/event.py
+++ b/backend/taxonomy_time_machine/event.py
@@ -1,12 +1,12 @@
-from datetime import datetime
-
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 
 
 class EventName(Enum):
     Create = "create"
     Delete = "delete"
+    Merge = "merge"
     Update = "alter"  # TODO: change me to Update
 
 
@@ -20,6 +20,7 @@ class Event:
     name: str | None = None
     rank: str | None = None
     parent_id: str | None = None
+    merged_into_id: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -36,6 +37,7 @@ class Event:
             rank=data.get("rank"),
             parent_id=data.get("parent_id"),
             taxonomy_source_id=data.get("taxonomy_source_id"),
+            merged_into_id=data.get("merged_into_id"),
         )
 
     def to_dict(self) -> dict:
@@ -47,4 +49,5 @@ class Event:
             "name": self.name,
             "rank": self.rank,
             "taxonomy_source_id": self.taxonomy_source_id,
+            "merged_into_id": self.merged_into_id,
         }

--- a/backend/taxonomy_time_machine/load_data.py
+++ b/backend/taxonomy_time_machine/load_data.py
@@ -10,11 +10,13 @@ from sqlalchemy.orm import sessionmaker
 from taxonomy import Taxonomy
 from tqdm import tqdm
 
-from .event import Event, EventName
 from . import TimeMachine
+from .event import Event, EventName
+from .models import (
+    Taxonomy as TaxonomyModel,
+)
 from .models import (
     TaxonomySource,
-    Taxonomy as TaxonomyModel,
 )
 
 
@@ -38,6 +40,27 @@ def load_current_tax_id_to_node(database_path: str) -> dict[str, Event]:
     """Load current tax ID to node state"""
 
     return TimeMachine(database_path=database_path).get_most_recent_events()
+
+
+def load_merged_dump(dump_path: Path) -> dict[str, str]:
+    """Load and parse merged.dmp to identify old tax IDs that have been merge into new ones.
+    The merged format uses \t|\t as a field separator and \t|\n as the row terminator and
+    organizes the data as old_taxid -> new_taxid.
+    """
+
+    merged_path = dump_path / "merged.dmp"
+    merges = {}
+
+    if not merged_path.exists():
+        return merges
+
+    with open(merged_path) as f:
+        for line in f:
+            # strip the row terminator, then split the fields
+            old, new = line.rstrip("\t|\n").split("\t|\t")
+            merges[old] = new
+
+    return merges
 
 
 def setup_sqlite_performance(engine):
@@ -107,6 +130,7 @@ def main() -> None:
             taxonomy_source_id = taxonomy_source.id
 
         tax = Taxonomy.from_ncbi(str(taxdump_path))
+        merged = load_merged_dump(taxdump_path)
         tqdm.write(f"--- loaded {taxdump_path}: {tax}")
 
         total_seen_taxa += len(tax)
@@ -162,18 +186,31 @@ def main() -> None:
         # append deletions
         if last_tax_ids is not None:
             for tax_id in last_tax_ids - seen_tax_ids:
-                # Store the parent_id so that we can find the deletion events by parent_id
-                # (useful for excluding deleted children from get_children)
-                events.append(
-                    Event(
-                        event_name=EventName.Delete,
-                        tax_id=tax_id,
-                        # taxonomy library type annotation is wrong?
-                        parent_id=last_tax[tax_id].parent if last_tax else None,  # mypy: ignore
-                        version_date=taxdump_date,
-                        taxonomy_source_id=taxonomy_source_id,
+                # this taxid was merged into another taxid
+                if tax_id in merged:
+                    events.append(
+                        Event(
+                            event_name=EventName.Merge,
+                            tax_id=tax_id,
+                            parent_id=last_tax[tax_id].parent if last_tax else None,  # mypy: ignore
+                            version_date=taxdump_date,
+                            taxonomy_source_id=taxonomy_source_id,
+                            merged_into_id=merged[tax_id],
+                        )
                     )
-                )
+                else:
+                    # Store the parent_id so that we can find the deletion events by parent_id
+                    # (useful for excluding deleted children from get_children)
+                    events.append(
+                        Event(
+                            event_name=EventName.Delete,
+                            tax_id=tax_id,
+                            # taxonomy library type annotation is wrong?
+                            parent_id=last_tax[tax_id].parent if last_tax else None,  # mypy: ignore
+                            version_date=taxdump_date,
+                            taxonomy_source_id=taxonomy_source_id,
+                        )
+                    )
 
                 # remove from tax_id_to_node in case this tax ID gets re-created
                 del tax_id_to_node[tax_id]
@@ -216,6 +253,7 @@ def main() -> None:
                     rank=item["rank"],
                     name=item["name"],
                     taxonomy_source_id=item["taxonomy_source_id"],
+                    merged_into_id=item["merged_into_id"],
                 )
                 for item in batch
             ]
@@ -231,7 +269,11 @@ def main() -> None:
     print("--- rebuilding FTS index")
     with engine.connect() as conn:
         conn.execute(text("DELETE FROM name_fts"))
-        conn.execute(text("INSERT INTO name_fts(name) SELECT DISTINCT name FROM taxonomy WHERE name IS NOT NULL"))
+        conn.execute(
+            text(
+                "INSERT INTO name_fts(name) SELECT DISTINCT name FROM taxonomy WHERE name IS NOT NULL"
+            )
+        )
         conn.commit()
     print("--- done")
 

--- a/backend/taxonomy_time_machine/models.py
+++ b/backend/taxonomy_time_machine/models.py
@@ -30,6 +30,7 @@ class Taxonomy(Base):
     parent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     rank: Mapped[str | None] = mapped_column(Text, nullable=True)
     name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    merged_into_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationship to source
     source: Mapped[TaxonomySource] = relationship(back_populates="taxonomy_records")

--- a/backend/taxonomy_time_machine/time_machine.py
+++ b/backend/taxonomy_time_machine/time_machine.py
@@ -1,8 +1,8 @@
-from datetime import datetime
-from functools import lru_cache
 import logging
 import sqlite3
 import time
+from datetime import datetime
+from functools import lru_cache
 from typing import Literal
 
 from .event import Event, EventName
@@ -173,7 +173,11 @@ class TimeMachine:
         # *still* query_tax_id. remove these rows
 
         child_tax_ids = {e.tax_id for e in parent_events}
-        deleted_tax_ids = {e.tax_id for e in parent_events if e.event_name is EventName.Delete}
+        unused_tax_ids = {
+            e.tax_id
+            for e in parent_events
+            if (e.event_name is EventName.Delete) or (e.event_name is EventName.Merge)
+        }
         child_events = []
 
         # TODO: do this in a single db query
@@ -181,20 +185,20 @@ class TimeMachine:
             if ee := self.get_events(tax_id=child_tax_id, as_of=as_of, query_key="tax_id"):
                 last_event = ee[-1]
 
-                # catch tax IDs that were deleted then re-created
+                # catch tax IDs that were deleted/merged then re-created
                 if (
-                    last_event.event_name is not EventName.Delete
-                    and last_event.tax_id in deleted_tax_ids
+                    last_event.event_name not in {EventName.Delete, EventName.Merge}
+                    and last_event.tax_id in unused_tax_ids
                 ):
-                    deleted_tax_ids.remove(last_event.tax_id)
+                    unused_tax_ids.remove(last_event.tax_id)
+
                 child_events.append(ee[-1])
 
         keep_tax_ids = {c.tax_id for c in child_events if c.parent_id == tax_id}
         events = [e for e in parent_events if e.tax_id in keep_tax_ids]
 
         # 3. remove any deleted rows
-        events = [e for e in events if e.tax_id not in deleted_tax_ids]
-
+        events = [e for e in events if e.tax_id not in unused_tax_ids]
         # for each tax ID, get the *latest* parent_id
         # if that parent_id == tax_id then keep it
 
@@ -215,8 +219,8 @@ class TimeMachine:
         # make sure the row is still a child of tax_id
         rows = [r for r in latest_row_by_tax_id.values() if r.parent_id == tax_id]
 
-        # remove anything that got deleted
-        rows = [r for r in rows if r.event_name is not EventName.Delete]
+        # remove anything that got deleted/merged
+        rows = [r for r in rows if r.event_name not in {EventName.Delete, EventName.Merge}]
 
         self._profile("get_children", _profile_start, time.perf_counter())
         return rows
@@ -233,16 +237,16 @@ class TimeMachine:
         changed"""
         _profile_start = time.perf_counter()
 
-        # Find deletion date for this taxon (if deleted)
+        # Find deletion/merge date for this taxon (if deleted or merged)
         own_events = self.get_events(tax_id=tax_id)
         deletion_date = None
-        if own_events and own_events[-1].event_name == EventName.Delete:
+        if own_events and (own_events[-1].event_name in (EventName.Delete, EventName.Merge)):
             deletion_date = own_events[-1].version_date
 
         events = self._get_all_events_recursive(tax_id=tax_id)
         version_dates = sorted({e.version_date for e in events})
 
-        # Don't show lineage changes that happened after this taxon was deleted
+        # Don't show lineage changes that happened after this taxon was deleted/merged
         if deletion_date:
             version_dates = [d for d in version_dates if d <= deletion_date]
 
@@ -292,7 +296,9 @@ class TimeMachine:
                     break
 
             if parent is not None:
-                if parent.event_name == EventName.Delete:
+                if (parent.event_name == EventName.Delete) or (
+                    parent.event_name == EventName.Merge
+                ):
                     last_known = next((e for e in reversed(events) if e.name), None)
                     if last_known:
                         parent = Event(
@@ -302,6 +308,7 @@ class TimeMachine:
                             name=last_known.name,
                             rank=last_known.rank,
                             parent_id=parent.parent_id,
+                            merged_into_id=parent.merged_into_id,
                         )
                 lineage.append(parent)
             else:

--- a/backend/test_models.py
+++ b/backend/test_models.py
@@ -179,3 +179,59 @@ def test_lineage(db):
         "Bacteroidetes",
         "Bacteria",
     ]
+
+
+def test_get_merge_events(db):
+    events = db.get_events("10010")
+    assert events
+    assert len(events) == 2
+    assert events[1].merged_into_id == "11000"
+
+
+def test_get_lineage_after_merge(db):
+    # before the merge
+    events = db.get_lineage(tax_id="10010", as_of=D1)
+    assert [x.name for x in events] == [
+        "Taxon A",
+        "Genus Taxon",
+        "Phylum Taxon",
+        "Bacteria",
+    ]
+    assert [e for e in events if e.name == "Taxon A"][0].event_name is EventName.Create
+
+    # after the merge
+    events = db.get_lineage(tax_id="10010", as_of=D2)
+    assert [x.name for x in events] == [
+        "Taxon A",
+        "Genus Taxon",
+        "Phylum Taxon",
+        "Bacteria",
+    ]
+    assert [e for e in events if e.name == "Taxon A"][0].event_name is EventName.Merge
+    assert [e for e in events if e.name == "Taxon A"][0].merged_into_id == "11000"
+
+
+def test_get_children_merged_node(db):
+    # taxon a, before merge
+    children = db.get_children("10001", as_of=D1)
+    assert len(children) == 2
+
+    # after merge
+    children = db.get_children("10001", as_of=D2)
+    assert len(children) == 1
+    assert children[0].tax_id == "11000"
+
+
+def test_get_versions_merged(db):
+    # taxon a
+    versions = db.get_versions("10010")
+    assert len(versions) == 2
+
+    events = db.get_events("10010", as_of=versions[0])
+    assert len(events) == 1
+    assert events[0].event_name is EventName.Create
+
+    events = db.get_events("10010", as_of=versions[1])
+    assert len(events) == 2
+    assert events[0].event_name is EventName.Create
+    assert events[1].event_name is EventName.Merge

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -1343,13 +1343,13 @@ export default defineComponent({
   }
 
   .change-badge--merged {
-    background: #163029;
-    color: #7fa89a;
+    background: #0d2b3d;
+    color: #a6d8f5;
   }
 
   .merged-badge {
-    background: #163029;
-    color: #7fa89a;
+    background: #0d2b3d;
+    color: #a6d8f5;
   }
 
   .deleted-badge {

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -11,6 +11,7 @@ interface TaxonVersion {
   rank: string | null;
   version_date: string | null;
   event_name?: string;
+  merged_into_id?: string | null;
 }
 
 export default defineComponent({
@@ -623,12 +624,22 @@ export default defineComponent({
         <span class="taxon-info-box__name">{{ lineage[lineage.length - 1].name }}</span>
         <span class="taxon-info-box__id">tax ID {{ taxId }}</span>
         <span class="taxon-info-box__status">
-          <template v-if="isLatestVersion">
-            Most recent version
+          <template v-if="currentTaxon.event_name === 'EventName.Merge'">
+            As of {{ formatDisplayDate(version) }} ·
+            <span class="change-badge change-badge--merged">
+              merged into
+              <a href="#" @click.prevent="updateTaxId(currentTaxon.merged_into_id)">
+                {{ currentTaxon.merged_into_id }}
+              </a>
+              on {{ formatYearMonth(currentTaxon.version_date) }}
+            </span>
           </template>
           <template v-else-if="currentTaxon.event_name === 'EventName.Delete'">
             As of {{ formatDisplayDate(version) }} ·
             <span class="change-badge change-badge--deleted">deleted on {{ formatYearMonth(currentTaxon.version_date) }}</span>
+          </template>
+          <template v-else-if="isLatestVersion">
+            Most recent version
           </template>
           <template v-else-if="taxonChanges && (taxonChanges.nameChanged || taxonChanges.lineageChanged)">
             As of {{ formatDisplayDate(version) }} ·
@@ -661,15 +672,24 @@ export default defineComponent({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="node in lineage" :key="node.tax_id" :class="{ 'lineage-row--deleted': node.event_name === 'EventName.Delete' }">
+              <tr v-for="node in lineage" :key="node.tax_id" :class="{ 'lineage-row--deleted': node.event_name === 'EventName.Delete' || node.event_name === 'EventName.Merge' }">
                 <td>
-                  <span class="rank-badge" :class="getRankClass(node.rank)" :style="node.event_name === 'EventName.Delete' ? 'opacity: 0.5' : ''">
+                  <span class="rank-badge" :class="getRankClass(node.rank)" :style="(node.event_name === 'EventName.Delete' || node.event_name === 'EventName.Merge') ? 'opacity: 0.5' : ''">
                     {{ node.rank }}
                   </span>
                 </td>
                 <td class="name-cell">
-                  <span :style="node.event_name === 'EventName.Delete' ? 'text-decoration: line-through; opacity: 0.6' : ''">{{ node.name }}</span>
-                  <span v-if="node.event_name === 'EventName.Delete'" class="deleted-badge">deleted {{ formatShortDate(node.version_date) }}</span>
+                  <span :style="(node.event_name === 'EventName.Delete' || node.event_name === 'EventName.Merge') ? 'text-decoration: line-through; opacity: 0.6' : ''">{{ node.name }}</span>
+                  <span v-if="node.event_name === 'EventName.Delete'" class="deleted-badge">
+                      deleted {{ formatShortDate(node.version_date) }}
+                  </span>
+                  <span v-else-if="node.event_name === 'EventName.Merge'" class="merged-badge">
+                      merged into
+                      <a href="#" @click.prevent="updateTaxId(node.merged_into_id)" class="tax-id-link">
+                          {{ node.merged_into_id }}
+                      </a>
+                      {{ formatShortDate(node.version_date) }}
+                  </span>
                 </td>
                 <td>
                   <a
@@ -1252,6 +1272,23 @@ export default defineComponent({
   color: #c0392b;
 }
 
+.change-badge--merged {
+  background: #e6c7a8;
+  color: #7fa89a;
+}
+
+.merged-badge {
+  display: inline-block;
+  margin-left: 0.5em;
+  padding: 0.1em 0.45em;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: 600;
+  background: #e6c7a8;
+  color: #7fa89a;
+  vertical-align: middle;
+}
+
 .deleted-badge {
   display: inline-block;
   margin-left: 0.5em;
@@ -1305,9 +1342,20 @@ export default defineComponent({
     color: #ff8a80;
   }
 
+  .change-badge--merged {
+    background: #163029;
+    color: #7fa89a;
+  }
+
+  .merged-badge {
+    background: #163029;
+    color: #7fa89a;
+  }
+
   .deleted-badge {
     background: #4a1a1a;
     color: #ff8a80;
   }
+
 }
 </style>


### PR DESCRIPTION
This PR adds support for tracking taxa nodes that have been merged into another node. Previously these nodes were marked as `deleted`.
The taxdump data loader now parses `merged.dmp` and uses a new `EventName` called `Merge` to label taxa that were merged. Merged tax IDs are tracked using the `merged_into_id` field, which was added to the `TaxonSchema`.

Merge events will now show up on the page for each taxon and link to the new taxon:
<img width="1388" height="193" alt="Screenshot 2026-05-04 at 09 20 14" src="https://github.com/user-attachments/assets/6804ffae-58ad-4ca2-b7da-29557d4b9d86" />

Merge events are also displayed on the lineage table:
<img width="1373" height="418" alt="Screenshot 2026-05-04 at 09 20 25" src="https://github.com/user-attachments/assets/8d50fbb4-ad8c-4c52-809e-b27031eeb84b" />
