### PR TITLE
Update merge link out to point to date of merge

### DIFF
--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -477,6 +477,7 @@ export default defineComponent({
       query,
       error,
       onInput,
+      navigateToTaxon,
       updateTaxId,
       updateVersion,
       setTaxId,
@@ -628,7 +629,7 @@ export default defineComponent({
             As of {{ formatDisplayDate(version) }} ·
             <span class="change-badge change-badge--merged">
               merged into
-              <a href="#" @click.prevent="updateTaxId(currentTaxon.merged_into_id!)">
+              <a href="#" @click.prevent="navigateToTaxon(currentTaxon.merged_into_id)">
                 {{ currentTaxon.merged_into_id }}
               </a>
               on {{ formatYearMonth(currentTaxon.version_date) }}

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -629,7 +629,7 @@ export default defineComponent({
             As of {{ formatDisplayDate(version) }} ·
             <span class="change-badge change-badge--merged">
               merged into
-              <a href="#" @click.prevent="navigateToTaxon(currentTaxon.merged_into_id)">
+              <a href="#" @click.prevent="navigateToTaxon(currentTaxon.merged_into_id!)">
                 {{ currentTaxon.merged_into_id }}
               </a>
               on {{ formatYearMonth(currentTaxon.version_date) }}

--- a/frontend/src/components/TaxonomyTimeMachine.vue
+++ b/frontend/src/components/TaxonomyTimeMachine.vue
@@ -629,7 +629,7 @@ export default defineComponent({
             As of {{ formatDisplayDate(version) }} ·
             <span class="change-badge change-badge--merged">
               merged into
-              <a href="#" @click.prevent="navigateToTaxon(currentTaxon.merged_into_id!)">
+              <a href="#" @click.prevent="navigateToTaxon(currentTaxon.merged_into_id!, currentTaxon.version_date!)">
                 {{ currentTaxon.merged_into_id }}
               </a>
               on {{ formatYearMonth(currentTaxon.version_date) }}


### PR DESCRIPTION
This PR fixes a small visual bug that can occur when clicking on the link for a taxa that has been merged.
Sometimes, the link would take the user to a taxon page at a point in time when that taxon did not exist, resulting in an empty lineage table.
Now, the link for a merged taxon will take the user to the point in time that the merge occurred. 